### PR TITLE
Move CI commands to script files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Check cargo build
+        run: ./scripts/build.sh
+
       - name: Check formatting
-        run: cargo fmt --all --check
+        run: ./scripts/fmt.sh
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: ./scripts/clippy.sh
 
       - name: Run tests
-        run: cargo test --all
+        run: ./scripts/test.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "rote-mux"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+cargo build --all-features

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+cargo clippy --all-targets --all-features -- -D warnings

--- a/scripts/fmt.sh
+++ b/scripts/fmt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+cargo fmt --all --check

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Running build..."
+"$SCRIPT_DIR/build.sh"
+
+echo "==> Checking formatting..."
+"$SCRIPT_DIR/fmt.sh"
+
+echo "==> Running clippy..."
+"$SCRIPT_DIR/clippy.sh"
+
+echo "==> Running tests..."
+"$SCRIPT_DIR/test.sh"
+
+echo "==> All checks passed!"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+cargo test --all


### PR DESCRIPTION
## Summary
- Move cargo build/fmt/clippy/test commands from CI workflow to individual script files in `scripts/`
- Add `local-ci.sh` script that runs all checks locally
- Update CI workflow to call the scripts instead of inline commands

## Test plan
- [x] Run `./scripts/local-ci.sh` locally to verify all scripts work
- [x] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)