### PR TITLE
docs: add --generate-example usage to Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ The binary will be at `target/release/rote`.
 
 ## Quick Start
 
-Create a `rote.yaml` file:
+Generate an example configuration file and run it:
+
+```bash
+rote --generate-example > rote.yaml
+rote
+```
+
+Or create your own `rote.yaml` file:
 
 ```yaml
 default: ping-demo


### PR DESCRIPTION
## Summary
- Add documentation showing how to use `--generate-example` to generate an example configuration file
- Show the redirect pattern (`rote --generate-example > rote.yaml`) for quick setup

## Test plan
- [x] Verify the example command works: `rote --generate-example > rote.yaml && rote`

🤖 Generated with [Claude Code](https://claude.com/claude-code)