### PR TITLE
fix: clean up error messages in main

### DIFF
--- a/rote/src/bin/rote.rs
+++ b/rote/src/bin/rote.rs
@@ -25,7 +25,17 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() {
+    if let Err(e) = run().await {
+        eprintln!("error: {e}");
+        for cause in e.chain().skip(1) {
+            eprintln!("  caused by: {cause}");
+        }
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> anyhow::Result<()> {
     let args = Args::parse();
 
     if args.generate_example {
@@ -41,12 +51,14 @@ async fn main() -> anyhow::Result<()> {
 
     let yaml_dir = config_path
         .parent()
-        .ok_or_else(|| anyhow::anyhow!("Failed to determine config file directory"))?
+        .ok_or_else(|| anyhow::anyhow!("failed to determine config file directory"))?
         .to_path_buf();
 
-    let yaml_str = fs::read_to_string(&config_path).context("Reading the config file")?;
+    let yaml_str = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read config file '{}'", config_path.display()))?;
 
-    let config: Config = serde_yaml::from_str(&yaml_str).context("Parsing the config file")?;
+    let config: Config =
+        serde_yaml::from_str(&yaml_str).context("failed to parse config file as YAML")?;
 
     rote_mux::run(config, args.services, yaml_dir).await?;
 


### PR DESCRIPTION
## Summary
- Refactors main() to separate error handling from the core run() function
- Prints errors with lowercase "error:" prefix following standard CLI conventions
- Uses indented "caused by:" for error chains instead of the raw anyhow format
- Includes config file path in error messages for easier debugging

**Before:**
```
Error: Reading the config file

Caused by:
    No such file or directory (os error 2)
```

**After:**
```
error: failed to read config file 'nonexistent.yaml'
  caused by: No such file or directory (os error 2)
```

## Test plan
- [x] `cargo test` passes
- [x] Verified error output with missing config file
- [x] Verified error output with invalid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)