### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ Whenever the config format changes, update `example.yaml` and `README.md`.
 Integration test scripts should have names starting with the test name.
 The only allowed languages are Rust for application code, and bash for scripts used in tests.
 
+## Releases
+
+A new release is created by bumping the version in `Cargo.toml` in a pull request.
+
 ## Project Overview
 
 Rote is a terminal multiplexer for monitoring and managing multiple processes. Users define tasks in YAML with dependencies, and Rote starts them in topological order with a TUI for monitoring output.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "rote-mux"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rote/Cargo.toml
+++ b/rote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rote-mux"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "A terminal multiplexer for monitoring and managing multiple processes"
 license = "MIT"


### PR DESCRIPTION
## Summary
Bump version to 0.1.4.

### Changes since 0.1.3
- **feat**: Preserve YAML file order for task display (#8)
- **chore**: Update dependencies and add clippy instruction to CLAUDE.md (#9)
- **docs**: Add release process documentation to CLAUDE.md

## Test plan
- [x] All tests pass
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)